### PR TITLE
feat: added operation scope and setOperationScope to document model

### DIFF
--- a/src/document-model/custom/reducers/operation.ts
+++ b/src/document-model/custom/reducers/operation.ts
@@ -24,6 +24,7 @@ export const reducer: DocumentModelOperationOperations = {
                     reducer: action.input.reducer || '',
                     errors: [],
                     examples: [],
+                    scope: action.input.scope || 'global',
                 });
             }
         }
@@ -37,6 +38,19 @@ export const reducer: DocumentModelOperationOperations = {
                 if (latestSpec.modules[i].operations[j].id == action.input.id) {
                     latestSpec.modules[i].operations[j].name =
                         action.input.name || '';
+                }
+            }
+        }
+    },
+
+    setOperationScopeOperation(state, action) {
+        const latestSpec =
+            state.specifications[state.specifications.length - 1];
+        for (let i = 0; i < latestSpec.modules.length; i++) {
+            for (let j = 0; j < latestSpec.modules[i].operations.length; j++) {
+                if (latestSpec.modules[i].operations[j].id == action.input.id) {
+                    latestSpec.modules[i].operations[j].scope =
+                        action.input.scope || 'global';
                 }
             }
         }
@@ -137,7 +151,7 @@ export const reducer: DocumentModelOperationOperations = {
         for (let i = 0; i < latestSpec.modules.length; i++) {
             if (latestSpec.modules[i].id == action.input.moduleId) {
                 latestSpec.modules[i].operations.sort(
-                    operationSorter(action.input.order)
+                    operationSorter(action.input.order),
                 );
             }
         }

--- a/src/document-model/gen/document-model.ts
+++ b/src/document-model/gen/document-model.ts
@@ -27,6 +27,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetModelId',
@@ -37,6 +38,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetModelExtension',
@@ -47,6 +49,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetModelDescription',
@@ -57,6 +60,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetAuthorName',
@@ -67,6 +71,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetAuthorWebsite',
@@ -77,6 +82,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -94,6 +100,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'UpdateChangeLogItem',
@@ -104,6 +111,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteChangeLogItem',
@@ -114,6 +122,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderChangeLogItems',
@@ -124,6 +133,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReleaseNewVersion',
@@ -134,6 +144,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -151,6 +162,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetModuleName',
@@ -161,6 +173,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetModuleDescription',
@@ -171,6 +184,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteModule',
@@ -181,6 +195,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderModules',
@@ -191,6 +206,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -208,6 +224,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationErrorCode',
@@ -218,6 +235,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationErrorName',
@@ -228,6 +246,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationErrorDescription',
@@ -238,6 +257,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationErrorTemplate',
@@ -248,6 +268,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteOperationError',
@@ -258,6 +279,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderOperationErrors',
@@ -268,6 +290,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -285,6 +308,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'UpdateOperationExample',
@@ -295,6 +319,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteOperationExample',
@@ -305,6 +330,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderOperationExamples',
@@ -315,6 +341,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -332,6 +359,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationName',
@@ -342,6 +370,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationSchema',
@@ -352,6 +381,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationDescription',
@@ -362,6 +392,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationTemplate',
@@ -372,6 +403,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetOperationReducer',
@@ -382,6 +414,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'MoveOperation',
@@ -392,6 +425,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteOperation',
@@ -402,6 +436,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderModuleOperations',
@@ -412,6 +447,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',
@@ -429,6 +465,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'SetInitialState',
@@ -439,6 +476,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'AddStateExample',
@@ -449,6 +487,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'UpdateStateExample',
@@ -459,6 +498,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'DeleteStateExample',
@@ -469,6 +509,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                         {
                             name: 'ReorderStateExamples',
@@ -479,6 +520,7 @@ export const documentModel: DocumentModelState = {
                             reducer: '',
                             examples: [],
                             errors: [],
+                            scope: 'global',
                         },
                     ],
                     id: '',

--- a/src/document-model/gen/object.ts
+++ b/src/document-model/gen/object.ts
@@ -20,7 +20,7 @@ export * from './operation-example/object';
 export * from './operation/object';
 export * from './state/object';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-unsafe-declaration-merging
 interface DocumentModel
     extends DocumentModel_Header,
         DocumentModel_Versioning,
@@ -30,6 +30,7 @@ interface DocumentModel
         DocumentModel_Operation,
         DocumentModel_State {}
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class DocumentModel extends BaseDocument<
     DocumentModelState,
     DocumentModelAction

--- a/src/document-model/gen/operation/actions.ts
+++ b/src/document-model/gen/operation/actions.ts
@@ -9,10 +9,12 @@ import {
     MoveOperationInput,
     DeleteOperationInput,
     ReorderModuleOperationsInput,
+    SetOperationScopeInput,
 } from '../types';
 
 export type AddOperationAction = Action<'ADD_OPERATION', AddOperationInput>;
 export type SetOperationNameAction = Action<'SET_OPERATION_NAME', SetOperationNameInput>;
+export type SetOperationScopeAction = Action<'SET_OPERATION_SCOPE', SetOperationScopeInput>;
 export type SetOperationSchemaAction = Action<'SET_OPERATION_SCHEMA', SetOperationSchemaInput>;
 export type SetOperationDescriptionAction = Action<'SET_OPERATION_DESCRIPTION', SetOperationDescriptionInput>;
 export type SetOperationTemplateAction = Action<'SET_OPERATION_TEMPLATE', SetOperationTemplateInput>;
@@ -24,6 +26,7 @@ export type ReorderModuleOperationsAction = Action<'REORDER_MODULE_OPERATIONS', 
 export type DocumentModelOperationAction = 
     | AddOperationAction
     | SetOperationNameAction
+    | SetOperationScopeAction
     | SetOperationSchemaAction
     | SetOperationDescriptionAction
     | SetOperationTemplateAction

--- a/src/document-model/gen/operation/creators.ts
+++ b/src/document-model/gen/operation/creators.ts
@@ -10,6 +10,7 @@ import {
     MoveOperationInput,
     DeleteOperationInput,
     ReorderModuleOperationsInput,
+    SetOperationScopeInput,
 } from '../types';
 import {
     AddOperationAction,
@@ -21,6 +22,7 @@ import {
     MoveOperationAction,
     DeleteOperationAction,
     ReorderModuleOperationsAction,
+    SetOperationScopeAction,
 } from './actions';
 
 export const addOperation = (input: AddOperationInput) =>
@@ -29,9 +31,15 @@ export const addOperation = (input: AddOperationInput) =>
         {...input}
     );
 
-export const setOperationName = (input: SetOperationNameInput) =>
+    export const setOperationName = (input: SetOperationNameInput) =>
     createAction<SetOperationNameAction>(
         'SET_OPERATION_NAME',
+        {...input}
+    );
+
+    export const setOperationScope = (input: SetOperationScopeInput) =>
+    createAction<SetOperationScopeAction>(
+        'SET_OPERATION_SCOPE',
         {...input}
     );
 

--- a/src/document-model/gen/operation/object.ts
+++ b/src/document-model/gen/operation/object.ts
@@ -10,7 +10,8 @@ import {
     MoveOperationInput,
     DeleteOperationInput,
     ReorderModuleOperationsInput,
-    DocumentModelState
+    DocumentModelState,
+    SetOperationScopeInput
 } from '../types';
 import {
     addOperation,
@@ -22,6 +23,7 @@ import {
     moveOperation,
     deleteOperation,
     reorderModuleOperations,
+    setOperationScope,
 } from './creators';
 import { DocumentModelAction } from '../actions';
 
@@ -34,6 +36,10 @@ export default class DocumentModel_Operation extends BaseDocument<
     
     public setOperationName(input: SetOperationNameInput) {
         return this.dispatch(setOperationName(input));
+    }
+
+    public setOperationScope(input: SetOperationScopeInput) {
+        return this.dispatch(setOperationScope(input));
     }
     
     public setOperationSchema(input: SetOperationSchemaInput) {

--- a/src/document-model/gen/operation/operations.ts
+++ b/src/document-model/gen/operation/operations.ts
@@ -8,12 +8,14 @@ import {
     MoveOperationAction,
     DeleteOperationAction,
     ReorderModuleOperationsAction,
+    SetOperationScopeAction,
 } from './actions';
 import { DocumentModelState } from '../types';
 
 export interface DocumentModelOperationOperations {
     addOperationOperation: (state: DocumentModelState, action: AddOperationAction) => void,
     setOperationNameOperation: (state: DocumentModelState, action: SetOperationNameAction) => void,
+    setOperationScopeOperation: (state: DocumentModelState, action: SetOperationScopeAction) => void,
     setOperationSchemaOperation: (state: DocumentModelState, action: SetOperationSchemaAction) => void,
     setOperationDescriptionOperation: (state: DocumentModelState, action: SetOperationDescriptionAction) => void,
     setOperationTemplateOperation: (state: DocumentModelState, action: SetOperationTemplateAction) => void,

--- a/src/document-model/gen/reducer.ts
+++ b/src/document-model/gen/reducer.ts
@@ -186,6 +186,11 @@ const stateReducer: ImmutableStateReducer<
             OperationReducer.setOperationNameOperation(state, action);
             break;
 
+        case 'SET_OPERATION_SCOPE':
+            z.SetOperationScopeInputSchema().parse(action.input);
+            OperationReducer.setOperationScopeOperation(state, action);
+            break;
+
         case 'SET_OPERATION_SCHEMA':
             z.SetOperationSchemaInputSchema().parse(action.input);
             OperationReducer.setOperationSchemaOperation(state, action);

--- a/src/document-model/gen/schema/types.ts
+++ b/src/document-model/gen/schema/types.ts
@@ -1,3 +1,5 @@
+import { OperationScope } from "../../../document";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = T | null | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -50,6 +52,7 @@ export type AddOperationInput = {
   reducer?: InputMaybe<Scalars['String']['input']>;
   schema?: InputMaybe<Scalars['String']['input']>;
   template?: InputMaybe<Scalars['String']['input']>;
+  scope?: InputMaybe<OperationScope>;
 };
 
 export type AddStateExampleInput = {
@@ -106,6 +109,8 @@ export type DocumentModelState = {
   name: Scalars['String']['output'];
   specifications: Array<DocumentSpecification>;
 };
+
+export type DocumentModelMeta = unknown;
 
 export type DocumentSpecification = {
   __typename?: 'DocumentSpecification';
@@ -389,6 +394,7 @@ export type Operation = {
   reducer: Maybe<Scalars['String']['output']>;
   schema: Maybe<Scalars['String']['output']>;
   template: Maybe<Scalars['String']['output']>;
+  scope: OperationScope;
 };
 
 export type OperationError = {
@@ -494,6 +500,11 @@ export type SetOperationErrorTemplateInput = {
 export type SetOperationNameInput = {
   id: Scalars['ID']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type SetOperationScopeInput = {
+  id: Scalars['ID']['input'];
+  scope: InputMaybe<OperationScope>;
 };
 
 export type SetOperationReducerInput = {

--- a/src/document-model/gen/schema/zod.ts
+++ b/src/document-model/gen/schema/zod.ts
@@ -43,6 +43,7 @@ import {
     SetOperationNameInput,
     SetOperationReducerInput,
     SetOperationSchemaInput,
+    SetOperationScopeInput,
     SetOperationTemplateInput,
     SetStateSchemaInput,
     State,
@@ -119,6 +120,7 @@ export function AddOperationInputSchema(): z.ZodObject<
         reducer: z.string().nullish(),
         schema: z.string().nullish(),
         template: z.string().nullish(),
+        scope: z.literal('local').or(z.literal('global')).nullish(),
     });
 }
 
@@ -299,6 +301,7 @@ export function OperationSchema(): z.ZodObject<Properties<Operation>> {
         reducer: z.string().nullable(),
         schema: z.string().nullable(),
         template: z.string().nullable(),
+        scope: z.literal('local').or(z.literal('global')),
     });
 }
 
@@ -492,6 +495,15 @@ export function SetOperationNameInputSchema(): z.ZodObject<
     return z.object({
         id: z.string(),
         name: z.string().nullish(),
+    });
+}
+
+export function SetOperationScopeInputSchema(): z.ZodObject<
+    Properties<SetOperationScopeInput>
+> {
+    return z.object({
+        id: z.string(),
+        scope: z.literal('global').or(z.literal('local')),
     });
 }
 

--- a/src/document/types.ts
+++ b/src/document/types.ts
@@ -65,6 +65,12 @@ export type ImmutableStateReducer<State, A extends Action> = (
 ) => State | void;
 
 /**
+ * Scope of an operation.
+ * Global: The operation is synchronized everywhere in the network. This is the default document operation.
+ * Local: The operation is applied only locally (to a local state). Used for local settings such as a drive's local path
+ */
+export type OperationScope = 'global' | 'local';
+/**
  * An operation that was applied to a {@link Document}.
  *
  * @remarks

--- a/src/document/types.ts
+++ b/src/document/types.ts
@@ -21,6 +21,8 @@ export type Action<T extends string = string, I = unknown> = {
     input: I;
     /** The attachments included in the action. */
     attachments?: AttachmentInput[] | undefined;
+    /** The scope of the action, can either be 'global' or 'local'. Defaults to 'global' */
+    scope?: OperationScope;
 };
 
 export type ActionWithAttachment<

--- a/src/document/utils/base.ts
+++ b/src/document/utils/base.ts
@@ -8,6 +8,7 @@ import {
     ImmutableStateReducer,
     Reducer,
     Immutable,
+    OperationScope,
 } from '../types';
 import { hash } from './node';
 import { LOAD_STATE, PRUNE, REDO, SET_NAME, UNDO } from '../actions/types';
@@ -38,6 +39,7 @@ export function createAction<A extends Action>(
     input?: A['input'],
     attachments?: Action['attachments'],
     validator?: () => { parse(v: unknown): A },
+    scope: OperationScope = 'global',
 ): A {
     if (!type) {
         throw new Error('Empty action type');
@@ -47,11 +49,15 @@ export function createAction<A extends Action>(
         throw new Error(`Invalid action type: ${type}`);
     }
 
-    const action = attachments ? { type, input, attachments } : { type, input };
+    const action: Action = { type, input, scope };
+
+    if (attachments) {
+        action['attachments'] = attachments;
+    }
 
     validator?.().parse(action);
 
-    return action as unknown as A;
+    return action as A;
 }
 
 /**

--- a/test/document-model/object.test.ts
+++ b/test/document-model/object.test.ts
@@ -114,6 +114,7 @@ describe('DocumentModel Class', () => {
             description: '<SetModuleExtension.description>',
             template: '<SetModuleExtension.template>',
             reducer: '<SetModuleExtension.reducer>',
+            scope: 'local',
         });
 
         model.addOperation({
@@ -141,6 +142,7 @@ describe('DocumentModel Class', () => {
                     reducer: '<SetModuleExtension.reducer>',
                     examples: [],
                     errors: [],
+                    scope: 'local',
                 },
             ],
         });
@@ -159,6 +161,7 @@ describe('DocumentModel Class', () => {
                     reducer: '',
                     examples: [],
                     errors: [],
+                    scope: 'global',
                 },
             ],
         });
@@ -189,6 +192,7 @@ describe('DocumentModel Class', () => {
                     reducer: '',
                     examples: [],
                     errors: [],
+                    scope: 'global',
                 },
                 {
                     id: setModuleExtensionId,
@@ -199,6 +203,7 @@ describe('DocumentModel Class', () => {
                     reducer: '<SetModuleExtension.reducer>',
                     examples: [],
                     errors: [],
+                    scope: 'local',
                 },
             ],
         });
@@ -218,6 +223,7 @@ describe('DocumentModel Class', () => {
                 reducer: '<SetModuleExtension.reducer>',
                 examples: [],
                 errors: [],
+                scope: 'local',
             },
             {
                 id: addStateExampleId,
@@ -228,6 +234,7 @@ describe('DocumentModel Class', () => {
                 reducer: '',
                 examples: [],
                 errors: [],
+                scope: 'global',
             },
         ]);
 
@@ -251,6 +258,10 @@ describe('DocumentModel Class', () => {
             id: addStateExampleId,
             template: '<SetAuthorName.template>',
         });
+        model.setOperationScope({
+            id: addStateExampleId,
+            scope: 'local',
+        });
 
         const updatedValue = {
             id: addStateExampleId,
@@ -261,6 +272,7 @@ describe('DocumentModel Class', () => {
             reducer: '<SetAuthorName.reducer>',
             examples: [],
             errors: [],
+            scope: 'local',
         };
 
         expect(model.state.specifications[0].modules[1].operations[1]).toEqual(

--- a/test/document/reducer.test.ts
+++ b/test/document/reducer.test.ts
@@ -55,6 +55,7 @@ describe('Base reducer', () => {
         expect(setNameAction).toStrictEqual({
             type: SET_NAME,
             input: 'Document',
+            scope: 'global',
         });
     });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -32,9 +32,10 @@ export const countReducer = createReducer<CountState, CountAction>(
 );
 
 export const mapOperations = (operations: Operation[]) => {
-    return operations.map(({ input, type, index }) => ({
+    return operations.map(({ input, type, index, scope }) => ({
         input,
         type,
         index,
+        scope,
     }));
 };


### PR DESCRIPTION
This repository needs to be migrated to make use of @powerhouse-inc/powerhouse to autogenerate the code from the document model spec. I've create an issue to address that: #7.

For this feature I implemented the changes manually