### PR TITLE
Allow reducers to dispatch operations to the caller

### DIFF
--- a/src/document-model/gen/object.ts
+++ b/src/document-model/gen/object.ts
@@ -1,5 +1,5 @@
 import { DocumentModelState } from './types';
-import { Action, ExtendedState } from '../../document';
+import { ExtendedState, Signal } from '../../document';
 import { applyMixins, BaseDocument } from '../../document/object';
 import { DocumentModelAction } from './actions';
 import { reducer } from './reducer';
@@ -39,7 +39,7 @@ class DocumentModel extends BaseDocument<
 
     constructor(
         initialState?: Partial<ExtendedState<Partial<DocumentModelState>>>,
-        dispatch?: (action: Action) => void,
+        dispatch?: (signal: Signal) => void,
     ) {
         super(reducer, utils.createDocument(initialState), dispatch);
     }

--- a/src/document-model/gen/object.ts
+++ b/src/document-model/gen/object.ts
@@ -1,5 +1,5 @@
 import { DocumentModelState } from './types';
-import { ExtendedState } from '../../document';
+import { Action, ExtendedState } from '../../document';
 import { applyMixins, BaseDocument } from '../../document/object';
 import { DocumentModelAction } from './actions';
 import { reducer } from './reducer';
@@ -39,8 +39,9 @@ class DocumentModel extends BaseDocument<
 
     constructor(
         initialState?: Partial<ExtendedState<Partial<DocumentModelState>>>,
+        dispatch?: (action: Action) => void,
     ) {
-        super(reducer, utils.createDocument(initialState));
+        super(reducer, utils.createDocument(initialState), dispatch);
     }
 
     public saveToFile(path: string, name?: string) {

--- a/src/document/actions/index.ts
+++ b/src/document/actions/index.ts
@@ -1,3 +1,4 @@
+import { Signal } from '../signal';
 import {
     Action,
     Document,
@@ -16,7 +17,7 @@ function replayOperations<T, A extends Action>(
     initialState: Partial<ExtendedState<T>>,
     operations: Array<A | BaseAction>,
     reducer: ImmutableStateReducer<T, A>,
-    dispatch?: (action: Action) => void,
+    dispatch?: (signal: Signal) => void,
 ): Document<T, A> {
     // builds a new document from the initial data
     const document = createDocument<T, A>(initialState);

--- a/src/document/index.ts
+++ b/src/document/index.ts
@@ -1,5 +1,6 @@
 export * as actions from './actions/creators';
 export * from './object';
 export * from './reducer';
+export * from './signal';
 export * from './types';
 export * as utils from './utils';

--- a/src/document/object.ts
+++ b/src/document/object.ts
@@ -18,15 +18,21 @@ import { loadFromFile, saveToFile, readOnly } from './utils';
 export abstract class BaseDocument<T, A extends Action> {
     protected _document: Document<T, A>;
     private _reducer: Reducer<T, A>;
+    private _dispatch?: (action: Action) => void;
 
     /**
      * Constructs a BaseDocument instance with an initial state.
      * @param reducer - The reducer function that updates the state.
      * @param document - The initial state of the document.
      */
-    constructor(reducer: Reducer<T, A>, document: Document<T, A>) {
+    constructor(
+        reducer: Reducer<T, A>,
+        document: Document<T, A>,
+        dispatch?: (action: Action) => void,
+    ) {
         this._reducer = reducer;
         this._document = document;
+        this._dispatch = dispatch;
     }
 
     /**
@@ -35,7 +41,7 @@ export abstract class BaseDocument<T, A extends Action> {
      * @returns The Document instance.
      */
     protected dispatch(action: A | BaseAction) {
-        this._document = this._reducer(this._document, action);
+        this._document = this._reducer(this._document, action, this._dispatch);
         return this;
     }
 

--- a/src/document/object.ts
+++ b/src/document/object.ts
@@ -1,5 +1,6 @@
 import { loadState, prune, redo, setName, undo } from './actions';
-import { BaseAction } from './actions/types';
+import type { BaseAction } from './actions/types';
+import type { Signal } from './signal';
 import type {
     Action,
     AttachmentRef,
@@ -18,7 +19,7 @@ import { loadFromFile, saveToFile, readOnly } from './utils';
 export abstract class BaseDocument<T, A extends Action> {
     protected _document: Document<T, A>;
     private _reducer: Reducer<T, A>;
-    private _dispatch?: (action: Action) => void;
+    private _dispatch?: (signal: Signal) => void;
 
     /**
      * Constructs a BaseDocument instance with an initial state.
@@ -28,7 +29,7 @@ export abstract class BaseDocument<T, A extends Action> {
     constructor(
         reducer: Reducer<T, A>,
         document: Document<T, A>,
-        dispatch?: (action: Action) => void,
+        dispatch?: (signal: Signal) => void,
     ) {
         this._reducer = reducer;
         this._document = document;

--- a/src/document/reducer.ts
+++ b/src/document/reducer.ts
@@ -157,6 +157,7 @@ export function baseReducer<T, A extends Action>(
     document: Document<T, A>,
     action: A | BaseAction,
     customReducer: ImmutableStateReducer<T, A>,
+    dispatch?: (action: Action) => void,
 ) {
     // if the action is one the base document actions (SET_NAME, UNDO, REDO, PRUNE)
     // then runs the base reducer first
@@ -175,7 +176,7 @@ export function baseReducer<T, A extends Action>(
     newDocument = produce(newDocument, draft => {
         // the reducer runs on a immutable version of
         // provided state
-        const returnedDraft = customReducer(draft.state, action as A);
+        const returnedDraft = customReducer(draft.state, action as A, dispatch);
 
         // if the reducer creates a new state object instead
         // of mutating the draft then returns the new state

--- a/src/document/reducer.ts
+++ b/src/document/reducer.ts
@@ -17,6 +17,7 @@ import {
 import { z } from './schema';
 import { Action, Document, ImmutableStateReducer } from './types';
 import { isBaseAction, hashDocument } from './utils';
+import { Signal } from './signal';
 
 /**
  * Gets the next revision number based on the provided action.
@@ -157,7 +158,7 @@ export function baseReducer<T, A extends Action>(
     document: Document<T, A>,
     action: A | BaseAction,
     customReducer: ImmutableStateReducer<T, A>,
-    dispatch?: (action: Action) => void,
+    dispatch?: (signal: Signal) => void,
 ) {
     // if the action is one the base document actions (SET_NAME, UNDO, REDO, PRUNE)
     // then runs the base reducer first

--- a/src/document/signal.ts
+++ b/src/document/signal.ts
@@ -1,0 +1,26 @@
+export interface ISignal<T extends string = string, I = unknown> {
+    type: T;
+    input: I;
+}
+
+export type CreateChildDocumentInput = {
+    id: string;
+    documentType: string;
+    initialState?: unknown;
+};
+
+export type CreateChildDocumentSignal = ISignal<
+    'CREATE_CHILD_DOCUMENT',
+    CreateChildDocumentInput
+>;
+
+export type DeleteChildDocumentInput = {
+    id: string;
+};
+
+export type DeleteChildDocumentSignal = ISignal<
+    'DELETE_CHILD_DOCUMENT',
+    DeleteChildDocumentInput
+>;
+
+export type Signal = CreateChildDocumentSignal | DeleteChildDocumentSignal;

--- a/src/document/types.ts
+++ b/src/document/types.ts
@@ -42,6 +42,7 @@ export type ActionWithAttachment<
 export type Reducer<State, A extends Action> = (
     state: Document<State, A>,
     action: A | BaseAction,
+    dispatch?: (action: Action) => void,
 ) => Document<State, A>;
 
 /**
@@ -59,11 +60,13 @@ export type Reducer<State, A extends Action> = (
 export type ImmutableReducer<State, A extends Action> = (
     state: Draft<Document<State, A>>,
     action: A | BaseAction,
+    dispatch?: (action: Action) => void,
 ) => Document<State, A> | void;
 
 export type ImmutableStateReducer<State, A extends Action> = (
     state: Draft<State>,
     action: A,
+    dispatch?: (action: Action) => void,
 ) => State | void;
 
 /**

--- a/src/document/types.ts
+++ b/src/document/types.ts
@@ -4,6 +4,7 @@ import type { DocumentModelState } from '../document-model/';
 import type { BaseAction } from './actions/types';
 import { BaseDocument } from './object';
 import { FileInput } from './utils';
+import { Signal } from './signal';
 export { z } from './schema';
 export type * from './schema/types';
 export type { FileInput } from './utils';
@@ -42,7 +43,7 @@ export type ActionWithAttachment<
 export type Reducer<State, A extends Action> = (
     state: Document<State, A>,
     action: A | BaseAction,
-    dispatch?: (action: Action) => void,
+    dispatch?: (signal: Signal) => void,
 ) => Document<State, A>;
 
 /**
@@ -60,13 +61,13 @@ export type Reducer<State, A extends Action> = (
 export type ImmutableReducer<State, A extends Action> = (
     state: Draft<Document<State, A>>,
     action: A | BaseAction,
-    dispatch?: (action: Action) => void,
+    dispatch?: (signal: Signal) => void,
 ) => Document<State, A> | void;
 
 export type ImmutableStateReducer<State, A extends Action> = (
     state: Draft<State>,
     action: A,
-    dispatch?: (action: Action) => void,
+    dispatch?: (signal: Signal) => void,
 ) => State | void;
 
 /**

--- a/src/document/utils/base.ts
+++ b/src/document/utils/base.ts
@@ -82,8 +82,8 @@ export function createReducer<S = unknown, A extends Action = Action>(
     reducer: ImmutableStateReducer<S, A>,
     documentReducer = baseReducer,
 ): Reducer<S, A> {
-    return (document, action) => {
-        return documentReducer(document, action, reducer);
+    return (document, action, dispatch) => {
+        return documentReducer(document, action, reducer, dispatch);
     };
 }
 

--- a/test/document/reducer.test.ts
+++ b/test/document/reducer.test.ts
@@ -1,3 +1,4 @@
+import { CreateChildDocumentInput, utils } from '../../src/document';
 import { setName } from '../../src/document/actions';
 import { SET_NAME } from '../../src/document/actions/types';
 import {
@@ -84,11 +85,20 @@ describe('Base reducer', () => {
     });
 
     it('should dispatch trigger action', async () => {
-        expect.assertions(1);
+        expect.assertions(4);
         const document = createDocument();
+
+        const id = utils.hashKey();
         const reducer = createReducer((_state, action, dispatch) => {
             if (action.type === 'CREATE_DOCUMENT') {
-                dispatch?.({ type: 'CREATE_CHILD_DOCUMENT', input: '' });
+                dispatch?.({
+                    type: 'CREATE_CHILD_DOCUMENT',
+                    input: {
+                        id,
+                        documentType: 'test',
+                        initialState: { value: 'test' },
+                    },
+                });
             }
         });
 
@@ -99,6 +109,10 @@ describe('Base reducer', () => {
 
         reducer(document, triggerAction, action => {
             expect(action.type).toBe('CREATE_CHILD_DOCUMENT');
+            const input = action.input as CreateChildDocumentInput;
+            expect(input.id).toBe(id);
+            expect(input.documentType).toBe('test');
+            expect(input.initialState).toStrictEqual({ value: 'test' });
         });
     });
 });

--- a/test/document/reducer.test.ts
+++ b/test/document/reducer.test.ts
@@ -1,6 +1,10 @@
 import { setName } from '../../src/document/actions';
 import { SET_NAME } from '../../src/document/actions/types';
-import { createAction, createDocument } from '../../src/document/utils';
+import {
+    createAction,
+    createDocument,
+    createReducer,
+} from '../../src/document/utils';
 import { emptyReducer } from '../helpers';
 
 describe('Base reducer', () => {
@@ -77,5 +81,24 @@ describe('Base reducer', () => {
                 input: 0 as unknown as string,
             }),
         ).toThrow();
+    });
+
+    it('should dispatch trigger action', async () => {
+        expect.assertions(1);
+        const document = createDocument();
+        const reducer = createReducer((_state, action, dispatch) => {
+            if (action.type === 'CREATE_DOCUMENT') {
+                dispatch?.({ type: 'CREATE_CHILD_DOCUMENT', input: '' });
+            }
+        });
+
+        const triggerAction = {
+            type: 'CREATE_DOCUMENT',
+            input: '',
+        };
+
+        reducer(document, triggerAction, action => {
+            expect(action.type).toBe('CREATE_CHILD_DOCUMENT');
+        });
     });
 });


### PR DESCRIPTION
Fixes #10.
Added a listener to the base reducer function so an action can be dispatched from a reducer. This action is to be handled by the caller of the reducer. 
An example of this is the DocumentDrive, which should dispatch CREATE_CHILD_DOCUMENT when there is a CREATE_DOCUMENT operation.

Eventually, we could implement something similar to [custom middleware](https://redux.js.org/usage/writing-custom-middleware) in Redux. Where a set of functions can be passed to a reducer to enhance its behaviour.
Apart from handling side effects like this issue, it could allow an operation to be changed before it's processed by the reducer, enforce access control, etc.