### PR TITLE
Keep operation timestamp when replaying operations

### DIFF
--- a/test/document-model/zip.test.ts
+++ b/test/document-model/zip.test.ts
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import { actions, reducer, utils } from '../../src/document-model';
+import { actions as baseActions } from '../../src/document';
+
+describe('DocumentModel Class', () => {
+    const tempDir = './test/document/temp/document-model/zip';
+    let timestamp = '';
+    beforeAll(() => {
+        if (!fs.existsSync(tempDir))
+            fs.mkdirSync(tempDir, {
+                recursive: true,
+            });
+    });
+
+    afterAll(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should save to zip', async () => {
+        let documentModel = utils.createDocument();
+        documentModel = reducer(
+            documentModel,
+            actions.setModelId({ id: 'powerhouse/test' }),
+        );
+        await utils.saveToFile(documentModel, tempDir, 'test');
+        expect(fs.existsSync(`${tempDir}/test.phdm.zip`)).toBe(true);
+
+        // keeps operation timestamp to check when loading
+        timestamp = documentModel.operations.global[0].timestamp;
+    });
+
+    it('should load from zip', async () => {
+        const documentModel = await utils.loadFromFile(
+            `${tempDir}/test.phdm.zip`,
+        );
+        expect(documentModel.state.global.id).toBe('powerhouse/test');
+        expect(documentModel.operations.global).toStrictEqual([
+            {
+                hash: 'xmstBdekoMQJQXwUZaOcv/Q/d9Q=',
+                index: 0,
+                input: { id: 'powerhouse/test' },
+                scope: 'global',
+                type: 'SET_MODEL_ID',
+                timestamp,
+            },
+        ]);
+    });
+
+    it('should keep undo state when loading from zip', async () => {
+        let documentModel = utils.createDocument();
+        documentModel = reducer(
+            documentModel,
+            actions.setModelId({ id: 'powerhouse/test' }),
+        );
+        documentModel = reducer(documentModel, baseActions.undo());
+        expect(documentModel.state.global.id).toBe('');
+
+        const timestamp = documentModel.operations.global[0].timestamp;
+        await utils.saveToFile(documentModel, tempDir, 'test2');
+
+        const loadedDocumentModel = await utils.loadFromFile(
+            `${tempDir}/test2.phdm.zip`,
+        );
+        expect(loadedDocumentModel.state.global.id).toBe('');
+        expect(loadedDocumentModel.operations.global).toStrictEqual([
+            {
+                hash: 'xmstBdekoMQJQXwUZaOcv/Q/d9Q=',
+                index: 0,
+                input: { id: 'powerhouse/test' },
+                scope: 'global',
+                type: 'SET_MODEL_ID',
+                timestamp,
+            },
+        ]);
+
+        expect(loadedDocumentModel).toStrictEqual(documentModel);
+    });
+});


### PR DESCRIPTION
Reuse operation timestamps when a documents is rebuilt from its operations. Before whenever a document was loaded from a zip, we were losing the original timestamps of the operations.

Fixed some bugs along with types and code organization improvements:
- utility function that implements the logic of building a document from its initial state and a list of operations. This will be used in the document drive for instance
- utility function that flattens all operations across scopes and sorts them by timestamp
- scopes are handled a bit more dynamically
- loadState operation was not being appended with a timestamp/hash/index
- UNDO/REDO operations were wrongly changing the hash of the undone/redone operation