### PR TITLE
feat: build separate bundles for ejs and cjs with their own package json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,20 +2,20 @@
     "env": {
         "browser": true,
         "es2016": true,
-        "node": true
+        "node": true,
     },
     "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/strict-type-checked",
         "plugin:@typescript-eslint/stylistic-type-checked",
-        "plugin:prettier/recommended"
+        "plugin:prettier/recommended",
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
         "sourceType": "module",
         "tsconfigRootDir": ".",
-        "project": true
+        "project": "./tsconfig.test.json",
     },
     "plugins": ["@typescript-eslint"],
     "rules": {
@@ -48,8 +48,8 @@
         "@typescript-eslint/prefer-reduce-type-parameter": "off",
         "@typescript-eslint/no-unused-vars": [
             1,
-            { "ignoreRestSiblings": true }
+            { "ignoreRestSiblings": true },
         ],
-        "@typescript-eslint/ban-ts-comment": "warn"
-    }
+        "@typescript-eslint/ban-ts-comment": "warn",
+    },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "document-model",
-    "version": "1.0.47",
+    "version": "1.0.50",
     "license": "AGPL-3.0-only",
     "private": false,
     "files": [

--- a/package.json
+++ b/package.json
@@ -23,32 +23,32 @@
     "exports": {
         ".": {
             "node": {
-                "import": "./dist/node/index.js",
-                "require": "./dist/node/index.cjs",
+                "import": "./dist/node/es/index.js",
+                "require": "./dist/node/cjs/index.cjs",
                 "types": "./dist/node/index.d.ts"
             },
-            "import": "./dist/browser/index.js",
-            "require": "./dist/browser/index.cjs",
+            "import": "./dist/browser/es/index.js",
+            "require": "./dist/browser/cjs/index.cjs",
             "types": "./dist/browser/index.d.ts"
         },
         "./document": {
             "node": {
-                "import": "./dist/node/document.js",
-                "require": "./dist/node/document.cjs",
+                "import": "./dist/node/es/document.js",
+                "require": "./dist/node/cjs/document.js",
                 "types": "./dist/node/document.d.ts"
             },
-            "import": "./dist/browser/document.js",
-            "require": "./dist/browser/document.cjs",
+            "import": "./dist/browser/es/document.js",
+            "require": "./dist/browser/cjs/document.js",
             "types": "./dist/browser/document.d.ts"
         },
         "./document-model": {
             "node": {
-                "import": "./dist/node/document-model.js",
-                "require": "./dist/node/document-model.cjs",
+                "import": "./dist/node/es/document-model.js",
+                "require": "./dist/node/cjs/document-model.js",
                 "types": "./dist/node/document-model.d.ts"
             },
-            "import": "./dist/browser/document-model.js",
-            "require": "./dist/browser/document-model.cjs",
+            "import": "./dist/browser/es/document-model.js",
+            "require": "./dist/browser/cjs/document-model.js",
             "types": "./dist/browser/document-model.d.ts"
         }
     },
@@ -75,6 +75,7 @@
         "typescript": "^5.3.3",
         "vite": "^5.0.11",
         "vite-plugin-dts": "^3.7.1",
+        "vite-plugin-generate-file": "^0.1.1",
         "vite-plugin-node-polyfills": "^0.19.0",
         "vitest": "^1.5.0"
     },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "dist"
     ],
     "types": "dist/node/index.d.ts",
-    "main": "dist/node/index.cjs",
-    "module": "dist/node/index.js",
-    "browser": "dist/browser/index.js",
+    "main": "dist/node/cjs/index.cjs",
+    "module": "dist/node/es/index.js",
+    "browser": "dist/browser/es/index.js",
     "type": "module",
     "scripts": {
         "check-types": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "document-model",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "license": "AGPL-3.0-only",
     "private": false,
     "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ devDependencies:
   vite-plugin-dts:
     specifier: ^3.7.1
     version: 3.7.1(@types/node@20.11.17)(rollup@4.10.0)(typescript@5.3.3)(vite@5.0.11)
+  vite-plugin-generate-file:
+    specifier: ^0.1.1
+    version: 0.1.1
   vite-plugin-node-polyfills:
     specifier: ^0.19.0
     version: 0.19.0(rollup@4.10.0)(vite@5.0.11)
@@ -1273,6 +1276,10 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /async@3.2.5:
+    resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
+    dev: true
+
   /available-typed-arrays@1.0.6:
     resolution: {integrity: sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==}
     engines: {node: '>= 0.4'}
@@ -1810,6 +1817,14 @@ packages:
       is-obj: 2.0.0
     dev: true
 
+  /ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      jake: 10.8.7
+    dev: true
+
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
     dependencies:
@@ -2116,6 +2131,12 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.2.0
+    dev: true
+
+  /filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+    dependencies:
+      minimatch: 5.1.6
     dev: true
 
   /fill-range@7.0.1:
@@ -2591,6 +2612,17 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /jake@10.8.7:
+    resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      async: 3.2.5
+      chalk: 4.1.2
+      filelist: 1.0.4
+      minimatch: 3.1.2
+    dev: true
+
   /jiti@1.21.0:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
@@ -2905,6 +2937,18 @@ packages:
       brorand: 1.1.0
     dev: true
 
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
   /mime@4.0.1:
     resolution: {integrity: sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==}
     engines: {node: '>=16'}
@@ -2938,6 +2982,13 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
+
+  /minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
     dev: true
 
   /minimatch@9.0.3:
@@ -4058,6 +4109,15 @@ packages:
       - '@types/node'
       - rollup
       - supports-color
+    dev: true
+
+  /vite-plugin-generate-file@0.1.1:
+    resolution: {integrity: sha512-V1TsLEXlrRiMZognzZqE3cgAHTJwQ84aE45gTR0Hhel6ROTQQU1i7qRbuyBqZI7QC4fUYLhugdaLPpaDpkB2pA==}
+    dependencies:
+      ejs: 3.1.10
+      js-yaml: 4.1.0
+      mime-types: 2.1.35
+      picocolors: 1.0.0
     dev: true
 
   /vite-plugin-node-polyfills@0.19.0(rollup@4.10.0)(vite@5.0.11):

--- a/test/document/event-vs-command.test.ts
+++ b/test/document/event-vs-command.test.ts
@@ -1,6 +1,6 @@
 // Command = action => should process the action and asign the index, timestamp, and hash
 // Event = operation => should keep the same operation information but execute the action input against the document
-
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { createDocument } from '../../src/document/utils';
 import { emptyReducer, wrappedEmptyReducer } from '../helpers';
 

--- a/test/document/local.test.ts
+++ b/test/document/local.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { prune, redo, undo } from '../../src/document/actions';
 import { createDocument } from '../../src/document/utils';
 import {

--- a/test/document/object.test.ts
+++ b/test/document/object.test.ts
@@ -1,3 +1,4 @@
+import { it, expect } from 'vitest';
 import { DocumentModel } from '../../src/document-model';
 
 it('should return a read only object on toDocument', () => {

--- a/test/document/reducer.test.ts
+++ b/test/document/reducer.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { Action, CreateChildDocumentInput, utils } from '../../src/document';
 import { setName } from '../../src/document/actions/creators';
 import { SET_NAME } from '../../src/document/actions/types';

--- a/test/document/skip-operations.test.ts
+++ b/test/document/skip-operations.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { Operation, utils } from '../../src/document';
 import { setName } from '../../src/document/actions/creators';
 import {

--- a/test/document/undo-redo.test.ts
+++ b/test/document/undo-redo.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import { noop, undo, redo } from '../../src/document/actions';
 import { createDocument, createExtendedState } from '../../src/document/utils';
 import { processUndoRedo } from '../../src/document/reducer';

--- a/test/document/utils.test.ts
+++ b/test/document/utils.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
     createDocument,
     getLocalFile,
@@ -46,7 +47,7 @@ describe('Base utils', () => {
         await expect(getLocalFile('as')).rejects.toBeDefined();
     });
 
-    it('should hash in browser and node', async () => {
+    it('should hash in browser and node', () => {
         expect(hashNode('test')).toEqual(hashBrowser('test'));
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     },
     "include": [
         "src/**/*",
-        "test/**/*",
         "node_modules/@types/wicg-file-system-access/index.d.ts",
         "*.config.ts",
         "*.config.js",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src/**/*",
+        "test/**/*",
+        "node_modules/@types/wicg-file-system-access/index.d.ts",
+        "*.config.ts",
+        "*.config.js",
+        "reset.d.ts",
+        "modules.d.ts"
+    ],
+    "exclude": ["src/document/utils/browser.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { Plugin, defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import generateFile from 'vite-plugin-generate-file';
 
 function replaceBrowserModules(): Plugin {
     return {
@@ -35,13 +36,12 @@ export default defineConfig(({ mode = 'node' }) => {
             lib: {
                 entry,
                 formats: ['es', 'cjs'],
-                fileName: (format, entryName) =>
-                    `${entryName}.${format === 'cjs' ? 'cjs' : 'js'}`,
             },
             rollupOptions: {
                 external,
                 output: {
-                    chunkFileNames: 'internal/[name]-[hash].js',
+                    entryFileNames: '[format]/[name].js',
+                    chunkFileNames: '[format]/internal/[name]-[hash].js',
                     exports: 'named',
                 },
             },
@@ -52,6 +52,22 @@ export default defineConfig(({ mode = 'node' }) => {
         plugins: [
             isBrowser ? replaceBrowserModules() : undefined,
             dts({ insertTypesEntry: true }),
+            generateFile([
+                {
+                    type: 'json',
+                    output: './es/package.json',
+                    data: {
+                        type: 'module',
+                    },
+                },
+                {
+                    type: 'json',
+                    output: `./cjs/package.json`,
+                    data: {
+                        type: 'commonjs',
+                    },
+                },
+            ]),
         ],
     };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig(({ mode = 'node' }) => {
             },
         },
         optimizeDeps: {
-            include: isBrowser ? ['sha.js/sha1'] : [],
+            include: isBrowser ? ['sha.js/sha1', 'sha.js/sha256'] : [],
         },
         plugins: [
             isBrowser ? replaceBrowserModules() : undefined,


### PR DESCRIPTION
Builds two separate folders for esm and commonjs. Also creates a package.json inside each folder with the correct type, `module` for esm and `CommonJS`from cjs.

Bundlers check the nearest package json of a file to decide with module system to use.